### PR TITLE
Port to use six for Py2 and Py3 and add Python 3 subpackage in spec

### DIFF
--- a/multilib/multilib.py
+++ b/multilib/multilib.py
@@ -13,7 +13,7 @@
 
 import os
 from fnmatch import fnmatch
-from ConfigParser import ConfigParser
+from six.moves import configparser
 
 class MultilibMethod(object):
     PREFER_64 = frozenset(
@@ -55,7 +55,7 @@ class FileMultilibMethod(MultilibMethod):
 
     def __init__(self, config='/etc/multilib.conf'):
         self.name = 'file'
-        self.cp = ConfigParser()
+        self.cp = configparser.ConfigParser()
         self.cp.read(config)
         self.list = self.cp.get('multilib', 'packages')
 
@@ -118,7 +118,7 @@ class RuntimeMultilibMethod(MultilibMethod):
 
     def __init__(self, config='/etc/multilib.conf'):
         self.name = 'runtime'
-        self.cp = ConfigParser()
+        self.cp = configparser.ConfigParser()
         self.cp.readfp(open(config, 'r'))
         self.runtime_whitelist = self.cp.get(self.name, 'white')
         self.runtime_blacklist = self.cp.get(self.name, 'black')

--- a/python-multilib.spec
+++ b/python-multilib.spec
@@ -1,22 +1,33 @@
 Name:       python-multilib
 Version:    1.1
-Release:    2%{?dist}
+Release:    3%{?dist}
 Summary:    A module for determining if a package is multilib or not
 Group:      Development/Libraries
 License:    GPLv2
 URL:        https://github.com/Zyzyx/python-multilib/
-Source0:    %{name}-%{version}.tar.bz2
+Source0:    https://github.com/Zyzyx/python-multilib/archive/v%{version}/%{name}-%{version}.tar.gz
 
-BuildArch:      noarch
+BuildArch:  noarch
+
 %description
 A Python module that supports several multilib "methods" useful for determining
 if a 32-bit package should be included with its 64-bit analogue in a compose.
 
+%package conf
+Summary:        Configuration files for %{name}
+
+%description conf
+This package provides the configuration files for %{name}.
+
 %package -n python2-multilib
 Summary:        A module for determining if a package is multilib or not
+%{?python_provide:%python_provide python2-multilib}
 BuildRequires:  python2-devel
 BuildRequires:  python2-setuptools
+BuildRequires:  python2-six
+Requires:       python2-six
 Requires:       python2
+Requires:       %{name}-conf = %{version}-%{release}
 
 %description -n python2-multilib
 A Python module that supports several multilib "methods" useful for determining
@@ -24,44 +35,53 @@ if a 32-bit package should be included with its 64-bit analogue in a compose.
 
 %package -n python3-multilib
 Summary:        A module for determining if a package is multilib or not
+%{?python_provide:%python_provide python3-multilib}
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
+BuildRequires:  python3-six
+Requires:       python3-six
 Requires:       python3
+Requires:       %{name}-conf = %{version}-%{release}
 
 %description -n python3-multilib
 A Python module that supports several multilib "methods" useful for determining
 if a 32-bit package should be included with its 64-bit analogue in a compose.
 
 
-
 %prep
 %setup -q
 
-
 %build
 %py2_build
-#py3_build
+%py3_build
 
 %install
 %py2_install
-#py3_install
+%py3_install
 
 %check
 #{__python2} setup.py test
 #{__python3} setup.py test
 
+%files conf
+%config(noreplace) %{_sysconfdir}/multilib.conf
+
 %files -n python2-multilib
 %license LICENSE
 %doc README.md
 %{python2_sitelib}/*
-%config(noreplace) %{_sysconfdir}/multilib.conf
 
-#files -n python3-multilib
-#license LICENSE
-#doc README.md
-#{python3_sitelib}/*
+%files -n python3-multilib
+%license LICENSE
+%doc README.md
+%{python3_sitelib}/*
+
 
 %changelog
+* Sun May 01 2016 Neal Gompa <ngompa13@gmail.com> - 1.1-3
+- Port to Python 3 and enable its subpackage
+- Split config file to its own subpackage
+
 * Thu Apr 07 2016 Dennis Gilmore <dennis@ausil.us> - 1.1-2
 - setup to make python3 down the road.
 - spec and srpm named python-multilib

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     license = "GPLv2",
     url = "https://github.com/Zyzyx/python-multilib.git",
     packages = packages,
+    install_requires = ['six'],
     package_data = {'': ['README.md', 'LICENSE']},
     data_files = [('/etc', ['etc/multilib.conf'])],
     test_suite      = "tests",


### PR DESCRIPTION
This pull request adds Python 3 support and enables the building of its subpackage in the spec.

I suggest bumping the version after merging this.
